### PR TITLE
fixed LANG different than en_US and unicode strings in window titles

### DIFF
--- a/export_events.py
+++ b/export_events.py
@@ -16,7 +16,7 @@ def loadEvents(fname):
   events = []
 
   try:
-    ws = open(fname, 'r').read().splitlines()
+    ws = open(fname, 'r').read().decode('utf-8').splitlines()
     events = []
     for w in ws:
       ix = w.find(' ') # find first space, that's where stamp ends
@@ -108,7 +108,7 @@ def updateEvents():
       print 'wrote ' + fwrite
 
   fwrite = os.path.join(RENDER_ROOT, 'export_list.json')
-  open(fwrite, 'w').write(json.dumps(out_list))
+  open(fwrite, 'w').write(json.dumps(out_list).encode('utf8'))
   print 'wrote ' + fwrite
 
 # invoked as script

--- a/keyfreq.sh
+++ b/keyfreq.sh
@@ -5,6 +5,8 @@
 # in logs/keyfreqX.txt every 9 seconds, where X is unix timestamp of 7am of the
 # recording day.
 
+LANG=en_US.utf8
+
 helperfile="logs/keyfreqraw.txt" # temporary helper file
 
 mkdir -p logs

--- a/logactivewin.sh
+++ b/logactivewin.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+LANG=en_US.utf8
+
 # logs the active window titles over time. Logs are written 
 # in logs/windowX.txt, where X is unix timestamp of 7am of the
 # recording day. The logs are written if a window change event occurs


### PR DESCRIPTION
- i18n environment causes no logging at all
- unicode strings in windows titles trigger exceptions in export_events.py
