### PR TITLE
changed default listening port

### DIFF
--- a/ulogme_serve.py
+++ b/ulogme_serve.py
@@ -12,7 +12,7 @@ IP = ""
 if len(sys.argv) > 1:
   PORT = int(sys.argv[1])
 else:
-  PORT = 8123
+  PORT = 8124
 
 # serve render/ folder, not current folder
 rootdir = os.getcwd()


### PR DESCRIPTION
Firefox blocks access to 8123 due to malware misuse, see http://www-archive.mozilla.org/projects/netlib/PortBanning.html

btw: It seems that everything works well in Firefox otherwise.
