### PR TITLE
Screensaver fixes

### DIFF
--- a/keyfreq.sh
+++ b/keyfreq.sh
@@ -21,7 +21,7 @@ do
   kill $PID
   
   # count number of key release events
-  num=$(cat $helperfile | grep release | wc -l)
+  num=$(grep release $helperfile | wc -l)
   
   # append unix time stamp and the number into file
   logfile="logs/keyfreq_$(python rewind7am.py).txt"

--- a/logactivewin.sh
+++ b/logactivewin.sh
@@ -17,8 +17,18 @@ last_write="0"
 lasttitle=""
 while true
 do
+	islocked=true
+	if command -v xscreensaver-command > /dev/null 2>&1; then
+		screensaverstate=$(xscreensaver-command -time | cut -f2 -d: | cut -f2-3 -d' ')
+		if [[ $screensaverstate =~ "screen non-blanked" ]]; then islocked=false; fi
+	elif command -v gnome-screensaver-command > /dev/null 2>&1; then
+		screensaverstate=$(gnome-screensaver-command -q 2>&1 /dev/null)
+		if [[ $screensaverstate =~ .*inactive.* ]]; then islocked=false; fi
+	else
+		# If we can't find the screensaver, assume it's missing.
+		islocked=false
+	fi
 
-	islocked=true; if [[ $(gnome-screensaver-command -q) =~ .*inactive.* ]]; then islocked=false; fi
 	if [ $islocked = true ]; then
 		curtitle="__LOCKEDSCREEN"
 	else 


### PR DESCRIPTION
Tried to fix ulogme for people using xscreensaver. I made it so the code tries xscreensaver first and if that command doesn't exist, it falls back to gnome-screensaver.

The order of those might be a bit controversial as some people might have both installed. This approach assumes that if you have both installed you installed xscreensaver yourself and are using it. I could add code to check whether xscreensaver or gnome-screensaver are running before populating the $screensaver state, which would be neater. 