### PR TITLE
Use `xinput` to not depend on access to `/dev/console` (root only).

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # ulogme
 
 
@@ -16,15 +15,15 @@ The project currently **only works on Ubuntu and OSX**, and uses new fancy **Pro
 
 ## Demo
 
-See a blog post (along with multiple screenshots) describing the project [here.](http://karpathy.github.io/2014/08/03/quantifying-productivity/)
+See a blog post (along with multiple screenshots) describing the project [here](http://karpathy.github.io/2014/08/03/quantifying-productivity/).
 
 ## Getting Started
 
 **To start recording**
 
 1. Clone the repository to some folder: `$ git clone https://github.com/karpathy/ulogme.git`
-2. If you're on Ubuntu, make sure you have the dependencies: `$ sudo apt-get install xdotool wmctrl`. On Fedora, you may also need `sudo yum install gnome-screensaver`.
-3. `cd` inside and run `$ ./ulogme.sh` (note: this will ask you for sudo authentication which is required for `showkey` command). This will launch two scripts. One records the frequency of keystrokes and the other records active window titles. Both write their logs into log files in the `logs/` directory. Every log file is very simply just the unix time stamp followed by data, one per line.
+2. If you're on Ubuntu, make sure you have the dependencies: `$ sudo apt-get install xdotool xinput wmctrl`. On Fedora, you may also need `sudo yum install gnome-screensaver`.
+3. `cd` inside and run `$ ./ulogme.sh` This will launch two scripts. One records the frequency of keystrokes and the other records active window titles. Both write their logs into log files in the `logs/` directory. Every log file is very simply just the unix time stamp followed by data, one per line.
 4. For **OSX** only: there might be an additional step where you have to go to System Preferences > Security & Privacy > Accessibility, and make sure that Terminal (or iTerm2, or whatever you use to launch ulogme) is checked. If it wasn't checked previously and you just checked it, you may need to restart ulogme. If you don't do this step, you might find that window logging works but keypress logging doesn't.
 
 **The user interface**
@@ -44,21 +43,21 @@ The user interface can switch between a single day view and an overview view by 
 
 #### Overview page
 
-- You can click the window titles to toggle them on and off from the visualization 
+- You can click the window titles to toggle them on and off from the visualization
 - Clicking on the vertical bars takes you to the full statistics for that day.
 
 ## Known issues
 - One Ubuntu user reported broken view with no data. On further inspection we found that the logs were corrupt. One of the lines in a file in `/logs` was, instead of looking as `{timestamp} {data}`  looked as `@@@@@@@{timestamp} {data}`, in other words an odd character was appended to the timestamp somehow. We manually erased these characters from the log file to fix the issue.
 - Legacy code note: if you used ulogme from before 28 July, you will have to run `$ python legacy_split_events.py` to convert your events files, once.
 - You may see *"address already in use"* if you try to run `python ulogme_serve.py`. Sometimes the system can get confused and takes a while to update what ports are being used. Use the optional argument to specify a different port, for example `python ulogme_serve.py 8124` and then go to `http://localhost:8124` instead, for example.
-- Overview page is blank. Are you sure your browser supports ECMAScript 6? Chrome should be fine, Firefox might not be, yet. 
+- Overview page is blank. Are you sure your browser supports ECMAScript 6? Chrome should be fine, Firefox might not be, yet.
 
 ## Contributing
 
 The Ubuntu and OSX code base are a little separate on the data collection side. However, they each just record very simple log files in `/logs`. Once the log files are written, `export_events.py` takes the log files, does some simple processing and writes the results into `.json` files in `/render`. The Javascript/HTML/CSS UI codebase is all common and all lives in `/render`.
 
 ### Ubuntu
-ulogme has three main parts: 
+ulogme has three main parts:
 
 1. Recording scripts `keyfreq.sh` and `logactivewin.sh`. You probably won't touch these.
 2. Webserver: `ulogme_serve.py` which wraps Python's `SimpleHTTPServer` and does some basic communication with the UI. For example, the UI can ask the server to write a note to a log file, or for a refresh.

--- a/keyfreq.sh
+++ b/keyfreq.sh
@@ -8,9 +8,6 @@
 LANG=en_US.utf8
 
 helperfile='/dev/shm/keyfreqraw.txt'
-## FIXME: Still potential security risk even when not logged to persistent storage.
-## Maybe rewrite script in Python and count STDOUT directly and send SIGINT
-## after 9 seconds.
 
 mkdir -p logs
 
@@ -18,10 +15,10 @@ trap 'kill $(jobs -p)' EXIT
 
 while true
 do
-  xinput test 11 > $helperfile &
+  xinput test 11 | tr -d '0-9' > $helperfile &
 
   ## In case you can not get `xinput` to work. Note that you will need to run `showkey` as root.
-  # showkey > $helperfile &
+  # showkey | tr -d '0-9' > $helperfile &
 
   # Work in windows of 9 seconds
   sleep 9

--- a/keyfreq.sh
+++ b/keyfreq.sh
@@ -15,7 +15,7 @@ trap 'kill $(jobs -p)' EXIT
 
 while true
 do
-  xinput test "${ULOGME_KEYBOARD_ID:-11}" | tr -d '0-9' > $helperfile &
+  xinput test "${ULOGME_KEYBOARD_ID:-11}" | tr -d '0-9' > "$helperfile" &
 
   ## In case you can not get `xinput` to work. Note that you will need to run `showkey` as root.
   # showkey | tr -d '0-9' > $helperfile &

--- a/keyfreq.sh
+++ b/keyfreq.sh
@@ -1,32 +1,42 @@
 #!/bin/bash
 
 
-# logs the key press frequency over 9 second window. Logs are written 
+# logs the key press frequency over 9 second window. Logs are written
 # in logs/keyfreqX.txt every 9 seconds, where X is unix timestamp of 7am of the
 # recording day.
 
 LANG=en_US.utf8
 
-helperfile="logs/keyfreqraw.txt" # temporary helper file
+helperfile='/dev/shm/keyfreqraw.txt'
+## FIXME: Still potential security risk even when not logged to persistent storage.
+## Maybe rewrite script in Python and count STDOUT directly and send SIGINT
+## after 9 seconds.
 
 mkdir -p logs
 
+trap 'kill $(jobs -p)' EXIT
+
 while true
 do
-  showkey > $helperfile &
-  PID=$!
-  
-  # work in windows of 9 seconds 
-  sleep 9
-  kill $PID
-  
-  # count number of key release events
-  num=$(cat $helperfile | grep release | wc -l)
-  
-  # append unix time stamp and the number into file
-  logfile="logs/keyfreq_$(python rewind7am.py).txt"
-  echo "$(date +%s) $num"  >> $logfile
-  echo "logged key frequency: $(date) $num release events detected into $logfile"
-  
-done
+  xinput test 11 > $helperfile &
 
+  ## In case you can not get `xinput` to work. Note that you will need to run `showkey` as root.
+  # showkey > $helperfile &
+
+  # Work in windows of 9 seconds
+  sleep 9
+
+  # shellcheck disable=SC2046
+  kill $(jobs -rp)
+  # shellcheck disable=SC2046
+  wait $(jobs -rp) 2>/dev/null
+
+  # Count number of key release events
+  num="$(grep --count release "$helperfile")"
+
+  # Append unix time stamp and the number into file
+  logfile="logs/keyfreq_$(python rewind7am.py).txt"
+  echo "$(date +%s) $num" >> "$logfile"
+  echo "logged key frequency: $(date) $num release events detected into $logfile"
+
+done

--- a/keyfreq.sh
+++ b/keyfreq.sh
@@ -15,7 +15,7 @@ trap 'kill $(jobs -p)' EXIT
 
 while true
 do
-  xinput test 11 | tr -d '0-9' > $helperfile &
+  xinput test "${ULOGME_KEYBOARD_ID:-11}" | tr -d '0-9' > $helperfile &
 
   ## In case you can not get `xinput` to work. Note that you will need to run `showkey` as root.
   # showkey | tr -d '0-9' > $helperfile &

--- a/ulogme.sh
+++ b/ulogme.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
+trap 'kill $(jobs -p)' EXIT
+
 if [ "$(uname)" == "Darwin" ]; then
   # This is a Mac
   ./osx/run_ulogme_osx.sh
 else
   # Assume Linux
-  sudo echo -n ""
-  sudo ./keyfreq.sh &
+  ./keyfreq.sh &
   ./logactivewin.sh
 fi


### PR DESCRIPTION
Closes #34

Additional improvements and fixes:
- Why use `cat`, `grep` and `wc` combined when `grep` can do all of this
  at once? Fixed. [shellcheck](https://www.shellcheck.net/) can make you
  aware of such things.
- Never store highly sensitive information like keystrokes (which
  potentially can contain passwords) on persistent storage.
- Terminate background processes when the main process gets killed.
- Suppress `bash` warning when background process dies.
- Updated and fixed README.md accordingly.
- Removed trailing whitespace.
