### PR TITLE
use system site packages

### DIFF
--- a/osx/osx_setup.sh
+++ b/osx/osx_setup.sh
@@ -1,11 +1,6 @@
 if [ -d ".env" ]; then
   source .env/bin/activate
 else
-  virtualenv .env
+  virtualenv --sytem-site-packages -p /usr/bin/python .env
   source .env/bin/activate
-
-  # Manually installing packages instead of using requirements.txt because they
-  # must be installed in this order to avoid insane build times
-  pip install -U pyobjc-core
-  pip install -U pyobjc
 fi


### PR DESCRIPTION
Is there a reason for installing pyobjc manually instead of using the system site packages ?
