### PR TITLE
Fix window title logging on Cinnamon 18

### DIFF
--- a/logactivewin.sh
+++ b/logactivewin.sh
@@ -25,8 +25,13 @@ do
 		screensaverstate=$(xscreensaver-command -time | cut -f2 -d: | cut -f2-3 -d' ')
 		if [[ $screensaverstate =~ "screen non-blanked" ]]; then islocked=false; fi
 	elif [[ $GDMSESSION == 'ubuntu' || $GDMSESSION == 'ubuntu-2d' || $GDMSESSION == 'gnome-shell' || $GDMSESSION == 'gnome-classic' || $GDMSESSION == 'gnome-fallback' || $GDMSESSION == 'cinnamon' ]]; then
-		# Assume the GNOME/Ubuntu/cinnamon folks are using gnome-screensaver.
-		screensaverstate=$(gnome-screensaver-command -q 2>&1 /dev/null)
+        	# cinnamon folks are using cinnamon-screensaver now :)
+        	if [[ $GDMSESSION == 'cinnamon' ]]; then
+            	screensaverstate=$(cinnamon-screensaver-command -q 2>&1 /dev/null)
+        	else
+		# Assume the GNOME/Ubuntu folks are using gnome-screensaver.
+            	screensaverstate=$(gnome-screensaver-command -q 2>&1 /dev/null)
+        	fi
 		if [[ $screensaverstate =~ .*inactive.* ]]; then islocked=false; fi
 	elif [[ $XDG_SESSION_DESKTOP == 'KDE' ]]; then
 		islocked=$(qdbus org.kde.screensaver /ScreenSaver org.freedesktop.ScreenSaver.GetActive)
@@ -69,7 +74,6 @@ do
 	lasttitle="$curtitle" # swap
 	sleep "$waittime" # sleep
 done
-
 
 
 


### PR DESCRIPTION
The default screensaver for Cinnamon is now cinnamon-screensaver not gnome-screensaver.